### PR TITLE
fix killing revenant fails no kill objective

### DIFF
--- a/maps/dmx.script
+++ b/maps/dmx.script
@@ -163,7 +163,7 @@ void activateCryptMonster()
     exitDoor.Lock();
 
     // spawn the crypt monster
-    spawnAI("-1259.62 -503.401 -295.708", "path_corner_139", CRYPT_MONSTER, "atdm:ai_undead_revenant", ANGLE_EAST, "2", false);
+    spawnAI("-1259.62 -503.401 -295.708", "path_corner_139", CRYPT_MONSTER, "atdm:ai_undead_revenant", ANGLE_EAST, "9", false);
 
     // wait a bit for the monster to reach his path_waitfortrigger
     sys.wait(2);


### PR DESCRIPTION
He was spawned with the wrong AI team set (guard instead of undead). Fixes #451 